### PR TITLE
Support for last Velocity versions, bug fixes and rcon-host property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,20 +66,20 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.6</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.65.Final</version>
+            <version>4.1.79.Final</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>15</maven.compiler.source>
+        <maven.compiler.target>15</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/src/main/java/me/uniodex/velocityrcon/VelocityRcon.java
+++ b/src/main/java/me/uniodex/velocityrcon/VelocityRcon.java
@@ -30,6 +30,8 @@ public class VelocityRcon {
     private final Logger logger;
 
     @Getter
+    private String rconHost = "127.0.0.1";
+    @Getter
     private int rconPort = 1337;
     @Getter
     private String rconPassword = "8Qnvb563haX26DDF";
@@ -57,6 +59,11 @@ public class VelocityRcon {
             logger.warn("Invalid rcon port. Shutting down.");
             return;
         }
+        rconHost = toml.getString("rcon-host");
+        if (rconHost == null) {
+            logger.warn("rcon-host is not specified in the config! 127.0.0.1 will be used.");
+            rconHost = "127.0.0.1";
+        }
         rconPassword = toml.getString("rcon-password");
         rconColored = toml.getBoolean("rcon-colored");
     }
@@ -72,7 +79,7 @@ public class VelocityRcon {
     }
 
     private void startListener() {
-        InetSocketAddress address = new InetSocketAddress(rconPort);
+        InetSocketAddress address = new InetSocketAddress(rconHost, rconPort);
         rconServer = new RconServer(server, rconPassword);
         logger.info("Binding rcon to address: /" + address.getHostName() + ":" + address.getPort());
 

--- a/src/main/java/me/uniodex/velocityrcon/commandsource/IRconCommandSource.java
+++ b/src/main/java/me/uniodex/velocityrcon/commandsource/IRconCommandSource.java
@@ -4,9 +4,12 @@ import com.velocitypowered.api.permission.PermissionFunction;
 import com.velocitypowered.api.permission.Tristate;
 import com.velocitypowered.api.proxy.ProxyServer;
 import lombok.Getter;
+import me.uniodex.velocityrcon.utils.Utils;
+import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import static com.velocitypowered.api.permission.PermissionFunction.ALWAYS_TRUE;
 
@@ -22,9 +25,22 @@ public class IRconCommandSource implements RconCommandSource {
         this.server = server;
     }
 
+    private void addToBuffer(Component message) {
+        String txt = LegacyComponentSerializer.legacySection().serialize(message);
+        txt = Utils.stripMcColor(txt);
+        if (buffer.length() != 0)
+            buffer.append("\n");
+        buffer.append(txt);
+    }
+
     @Override
-    public void sendMessage(@NonNull Component component) {
-        buffer.append(LegacyComponentSerializer.legacySection().serialize(component)).append("\n");
+    public void sendMessage(@NotNull Identity source, @NotNull Component message) {
+        addToBuffer(message);
+    }
+
+    @Override
+    public void sendMessage(@NonNull Component message) {
+        addToBuffer(message);
     }
 
     @Override

--- a/src/main/java/me/uniodex/velocityrcon/utils/Utils.java
+++ b/src/main/java/me/uniodex/velocityrcon/utils/Utils.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 public class Utils {
     public static final char COLOR_CHAR = '\u00A7';
     public static final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)" + COLOR_CHAR + "[0-9A-FK-OR]");
+    public static final Pattern STRIP_MC_COLOR_PATTERN = Pattern.compile("§[0-8abcdefklmnor]");
 
     public static String stripColor(final String input) {
         if (input == null) {
@@ -13,6 +14,15 @@ public class Utils {
 
         return STRIP_COLOR_PATTERN.matcher(input).replaceAll("");
     }
+
+    public static String stripMcColor(final String input) {
+        if (input == null) {
+            return null;
+        }
+
+        return STRIP_MC_COLOR_PATTERN.matcher(input).replaceAll("");
+    }
+
 
     public static boolean isInteger(String str) {
         return str.matches("-?\\d+");

--- a/src/main/resources/rcon.toml
+++ b/src/main/resources/rcon.toml
@@ -1,3 +1,4 @@
+rcon-host = "127.0.0.1"
 rcon-port = "1337"
 rcon-password = "extraordinary"
 rcon-colored = true


### PR DESCRIPTION
The current version of the plugin does not work on the current version of Velocity.

I decided to look into this. It was possible to build the plugin only after I put the latest versions of the dependencies in pom.xml. The plugin worked, but the responses to the commands did not come, and the `end`/`stop` commands did not work because Velocity allows them to be executed only from `ConsoleCommandSource`.

My changes:

- Changed versions on pom.xml so now it builds succesfully.
- Velocity sends some responses to `sendMessage(Identity source, Component message)` so i added this method to `IRconCommandSource`. I also fixed the redunant line break in the end of response which was always added by `append("\n")`.
- Velocity prevents the `stop` and `end` commands from being executed by anyone other than the `ConsoleCommandSource`. I have added a workaround for this.
- Added `rcon-host` property.

![Test](https://i.imgur.com/9qCiRbO.png)
Some built-in messages seem to be broken, but everything else works.

Tested on Velocity 3.1.2-SNAPSHOT